### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -28,10 +28,10 @@ def normalizeWhitespace(s, removeNewline=True):
 
 def formatCmdDocs(docs, name):
     doclines = docs.splitlines()
-    s = '%s %s' % (name, doclines.pop(0))
+    s = '{0!s} {1!s}'.format(name, doclines.pop(0))
     if doclines:
         doc = ' '.join(doclines)
-        s = '(%s) -- %s' % ('\x02' + s + '\x0F', doc)
+        s = '({0!s}) -- {1!s}'.format('\x02' + s + '\x0F', doc)
     return normalizeWhitespace(s)
 
 

--- a/log.py
+++ b/log.py
@@ -49,7 +49,7 @@ def exnToString(exn):
     """Turns a simple exception instance into a string (better than str(e))"""
     strE = str(exn)
     if strE:
-        return '%s: %s' % (exn.__class__.__name__, strE)
+        return '{0!s}: {1!s}'.format(exn.__class__.__name__, strE)
     else:
         return exn.__class__.__name__
 
@@ -63,7 +63,7 @@ def stackTrace(frame=None, compact=True):
             lineno = frame.f_lineno
             funcname = frame.f_code.co_name
             filename = os.path.basename(frame.f_code.co_filename)
-            L.append('[%s|%s|%s]' % (filename, funcname, lineno))
+            L.append('[{0!s}|{1!s}|{2!s}]'.format(filename, funcname, lineno))
             frame = frame.f_back
 
         return textwrap.fill(' '.join(L))
@@ -177,8 +177,8 @@ class Logger(logging.Logger):
         (E, er, tb) = sys.exc_info()
         del er
         tbinfo = traceback.extract_tb(tb)
-        path = '[%s]' % '|'.join(map(operator.itemgetter(2), tbinfo))
-        eStrId = '%s:%s' % (E, path)
+        path = '[{0!s}]'.format('|'.join(map(operator.itemgetter(2), tbinfo)))
+        eStrId = '{0!s}:{1!s}'.format(E, path)
         eId = hex(hash(eStrId) & 0xFFFFF)
         logging.Logger.exception(self, *args)
         self.error('Exception id: %s', eId)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:wolfy1339:Python-IRC-Bot?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:wolfy1339:Python-IRC-Bot?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)